### PR TITLE
Add unit deselection utility and fix weapons module

### DIFF
--- a/Test1/src/entities/UnitManager.lua
+++ b/Test1/src/entities/UnitManager.lua
@@ -134,6 +134,16 @@ function UnitManager.move_selected_unit_to(pixel_x, pixel_y)
     end
 end
 
+-- Deselect the currently selected unit and clear related UI state
+function UnitManager.deselect_unit()
+    local UIManager = require("src.systems.uimanager")
+    UnitManager.data.selected_unit = nil
+    UnitManager.data.show_movement_range = false
+    UnitManager.data.valid_movement_tiles = {}
+    UIManager.hide_unit_info()
+    UIManager.hide_post_move_menu()
+end
+
 function UnitManager.draw()
     if UnitManager.data.show_movement_range then
         love.graphics.setColor(0, 0, 1, 0.3)

--- a/Test1/src/entities/weapons.lua
+++ b/Test1/src/entities/weapons.lua
@@ -15,3 +15,5 @@ local weapons = {
         range = 2,
     },
 }
+
+return weapons


### PR DESCRIPTION
## Summary
- add UnitManager.deselect_unit to reset selection and UI state
- return weapons table from weapons module

## Testing
- `lua - <<'EOF'
package.path = 'Test1/?.lua;Test1/?/?.lua;Test1/src/?.lua;Test1/src/?/?.lua;' .. package.path
local UnitManager = require('src.entities.UnitManager')
local UIManager = require('src.systems.uimanager')
UnitManager.data.selected_unit = {has_acted=false, state={turn={has_acted=false}}}
UIManager.data.post_move_menu.visible = true
UIManager.data.unit_info.visible = true
UnitManager.deselect_unit()
assert(UnitManager.data.selected_unit == nil, 'selected unit not cleared')
assert(not UnitManager.data.show_movement_range, 'movement range still shown')
assert(UIManager.data.post_move_menu.visible == false, 'menu not hidden')
assert(UIManager.data.unit_info.visible == false, 'unit info not hidden')
print('deselect_unit test passed')
local weapons = require('src.entities.weapons')
assert(weapons.bow.damage == 12, 'weapons module return failed')
print('weapons return test passed')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_689d25f4c844832782894ddf5000d8a1